### PR TITLE
Host name in cache path

### DIFF
--- a/metvocab/cache.py
+++ b/metvocab/cache.py
@@ -54,8 +54,9 @@ class DataCache():
         if API is unreachable. Returns None if API fails and no cache
         exists.
         """
-        path = urllib.parse.urlparse(uri).path
-        path_list = path.split("/")
+        urlbits = urllib.parse.urlparse(uri)
+        path_list = urlbits.path.split("/")
+        path_list.insert(0, urlbits.netloc.split(":")[0])
 
         if path_list[-1] == "":
             raise ValueError("The provided uri is missing a path: '%s'", uri)


### PR DESCRIPTION
**Summary**:

The host name of the uri should be part of the cache path directory structure in case of name space conflicts.

**Related issue**:

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.