### PR TITLE
Add alias to CFStandard class

### DIFF
--- a/metvocab/cfstd.py
+++ b/metvocab/cfstd.py
@@ -34,6 +34,7 @@ class CFStandard():
     def __init__(self):
 
         self._standard_names = set()
+        self._alias_names = set()
         self._is_initialised = False
 
         # Meta Data
@@ -71,6 +72,7 @@ class CFStandard():
         https://cfconventions.org/standard-names.html
         """
         self._standard_names = set()
+        self._alias_names = set()
         self._is_initialised = False
 
         start_time = time.time()
@@ -86,6 +88,10 @@ class CFStandard():
                 cf_id = cf_elem.attrib.get("id", None)
                 if cf_id is not None:
                     self._standard_names.add(cf_id)
+            elif cf_elem.tag == "alias":
+                cf_id = cf_elem.attrib.get("id", None)
+                if cf_id is not None:
+                    self._alias_names.add(cf_id)
             elif cf_elem.tag == "version_number":
                 self._cf_version_number = cf_elem.text
             elif cf_elem.tag == "last_modified":
@@ -97,10 +103,15 @@ class CFStandard():
 
         return
 
-    def check_standard_name(self, value):
-        """Look up a value in the list of standard names."""
+    def check_standard_name(self, value, include_alias=False):
+        """Look up a value in the list of standard names, and optionally
+        in the alias list.
+        """
         if isinstance(value, str):
-            return value in self._standard_names
+            if value in self._standard_names:
+                return True
+            if include_alias and value in self._alias_names:
+                return True
         return False
 
 # END Class CFStandard

--- a/tests/test_cfstd.py
+++ b/tests/test_cfstd.py
@@ -88,11 +88,19 @@ def testCoreCFStandard_CheckStandardName():
     assert cfstd.check_standard_name(12345) is False
     assert cfstd.check_standard_name(None) is False
 
-    # Valid Names
+    # Valid Standard Names
     assert cfstd.check_standard_name("aerodynamic_particle_diameter") is True
     assert cfstd.check_standard_name("atmosphere_mole_content_of_water_vapor") is True
     assert cfstd.check_standard_name("atmosphere_momentum_diffusivity") is True
     assert cfstd.check_standard_name("mass_concentration_of_ammonia_in_air") is True
     assert cfstd.check_standard_name("mole_fraction_of_isoprene_in_air") is True
+
+    # Check Aliases
+    assert cfstd.check_standard_name("mass_fraction_of_o3_in_air", include_alias=False) is False
+    assert cfstd.check_standard_name("mass_fraction_of_o3_in_air", include_alias=True) is True
+    assert cfstd.check_standard_name("swell_wave_period", include_alias=False) is False
+    assert cfstd.check_standard_name("swell_wave_period", include_alias=True) is True
+    assert cfstd.check_standard_name("longwave_radiance", include_alias=False) is False
+    assert cfstd.check_standard_name("longwave_radiance", include_alias=True) is True
 
 # END Test testCoreCFStandard_CheckStandardName


### PR DESCRIPTION
**Summary**:

Add alias to CFStandard class

**Related issue**:

**Suggested reviewer(s)**:

**Reviewer checklist**:

* [ ] The headers of all files contain a reference to the repository license
* [ ] 100% test coverage of new code - meaning:
  * [ ] The overall test coverage increased or remained the same as before
  * [ ] Every function is accompanied with a test suite
  * [ ] Tests are both positive (testing that the function work as intended with valid data) and negative (testing that the function behaves as expected with invalid data, e.g., that correct exceptions are thrown)
  * [ ] Functions with optional arguments have separate tests for all options
* [ ] Examples are supported by doctests
* [ ] All tests are passing
* [ ] All names (e.g., files, classes, functions, variables) are explicit
* [ ] Documentation (as docstrings) is complete and understandable

The checklist is based on the S-ENDA conventions and definition of done (see [General Conventions](https://s-enda-documentation.readthedocs.io/en/latest/general_conventions.html)). The above points are not necessarily relevant to all contributions. In that case, please add a short explanation to help the reviewer.